### PR TITLE
Add ARCH_ONLY variable to makefile for create board-agnostic images

### DIFF
--- a/sdbuild/Makefile
+++ b/sdbuild/Makefile
@@ -293,14 +293,21 @@ qemu_check_$1:
 
 endef
 
+ifeq ($(ARCH_ONLY),)
 USED_ARCH := $(sort $(foreach board, $(BOARDS), $(value ARCH_$(board))))
-
 $(foreach board, $(BOARDS), $(eval $(call BOARD_SPECIFIC_RULES,$(board))))
 $(foreach arch, $(USED_ARCH), $(eval $(call ARCH_SPECIFIC_RULES,$(arch))))
+IMAGE_FILES := $(foreach image_var, $(patsubst %, IMAGE_%, $(BOARDS)), $(value $(image_var)))
+else
+USED_ARCH := $(ARCH_ONLY)
+$(foreach arch, $(USED_ARCH), $(eval $(call ARCH_SPECIFIC_RULES,$(arch))))
+IMAGE_FILES := $(foreach image_var, $(patsubst %, BASE_%, $(ARCH_ONLY)), $(value $(image_var)))
+endif
+
+
 
 BSP_FILES := $(foreach bsp_var, $(patsubst %, BSP_FILES_%, $(BOARDS)), $(value $(bsp_var)))
 BOOT_FILES := $(foreach boot_var, $(patsubst %, BOOT_FILES_%, $(BOARDS)), $(value $(boot_var)))
-IMAGE_FILES := $(foreach image_var, $(patsubst %, IMAGE_%, $(BOARDS)), $(value $(image_var)))
 ALL_PACKAGES := $(sort $(foreach board, $(BOARDS), $(value STAGE3_PACKAGES_$(board)) $(value STAGE4_PACKAGES_$(board))) \
 		$(foreach arch, $(USED_ARCH), $(value STAGE2_PACKAGES_$(arch)) $(value STAGE3_PACKAGES_$(arch))))
 PACKAGE_CLEAN := $(patsubst %,PACKAGE_CLEAN_%, $(ALL_PACKAGES))

--- a/sdbuild/README.md
+++ b/sdbuild/README.md
@@ -190,6 +190,21 @@ To generate the Petalinux BSP for future use:
 make bsp BOARDDIR=<absolute_path>/myboards
 ```
 
+To build the board-agnostic images and sysroot you can pass the `ARCH_ONLY`
+variable to make. This will cause the `images` target to build the architecture
+image.
+
+```Makefile
+make images ARCH_ONLY=arm
+```
+
+To use a board-agnostic image to build a board-specific image you can pass the
+`PREBUILT` variable
+
+```Makefile
+make PREBUILT=<image path> BOARDS=<board>
+```
+
 ## Custom Ubuntu Repository
 
 By default the SD build flow will pull from https://ports.ubuntu.com. This can


### PR DESCRIPTION
This will allow to split-up Jenkins stages in board-agnostics first, and the dependent board-specifics